### PR TITLE
docs: fix typos and grammar in the first line

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 <img src="https://raw.githubusercontent.com/projectsveltos/sveltos/main/docs/assets/logo.png" width="200">
 
-Please refere to sveltos [documentation](https://projectsveltos.github.io/sveltos/).
+Please refer to the Sveltos [documentation website](https://projectsveltos.github.io/sveltos/).
 
-## Contributing 
+## Contributing
 
 ❤️ Your contributions are always welcome! If you want to contribute, have questions, noticed any bug or want to get the latest project news, you can connect with us in the following ways:
 


### PR DESCRIPTION
## Summary

Just stumbled upon some typos and other issues on the first line of the README 😅 
- I was looking for the `.github` repo for https://github.com/projectsveltos/.github/pull/18 and stumbled into this repo/the docs website

### Details

- "refere" -> "refer"
  - "refer to" -> "refer to the"
- "sveltos" -> "Sveltos"
  - proper noun / name of the project, so should be capitalized
- "documentation" -> "documentation website"