### PR TITLE
Add a note on ConfigMap data size

### DIFF
--- a/docs/addons/raw_yaml.md
+++ b/docs/addons/raw_yaml.md
@@ -13,7 +13,7 @@ authors:
     - Gianluca Mardente
 ---
 
-The ClusterProfile *Spec.PolicyRefs* is a list of Secrets/ConfigMaps. Both Secrets and ConfigMaps data fields can be a list of key-value pairs. Any key is acceptable, and the value can be multiple objects in YAML or JSON format.
+The ClusterProfile *Spec.PolicyRefs* is a list of Secrets/ConfigMaps. Both Secrets and ConfigMaps data fields can be a list of key-value pairs. Any key is acceptable, and the value can be multiple objects in YAML or JSON format[^1].
 
 To create a Secret containing Calico YAMLs, use the below commands.
 
@@ -102,3 +102,5 @@ spec:
 Consider the provided ClusterProfile, when we have two workload clusters matching. One in the _foo_ namespace and another in the _bar_ namespace. Sveltos will search for the ConfigMap _contour-gateway_ in the _foo_ namespace for the Cluster in the _foo_ namespace and for a ConfigMap _contour-gateway_ in the _bar_ namespace for the Cluster in the _bar_ namespace.
 
 More ClusterProfile examples can be found [here](https://github.com/projectsveltos/sveltos-manager/tree/main/examples "Manage Kubernetes add-ons: examples").
+
+[^1]:A ConfigMap is not designed to hold large chunks of data. The data stored in a ConfigMap cannot exceed 1 MiB. If you need to store settings that are larger than this limit, you may want to consider mounting a volume or use a separate database or file service.


### PR DESCRIPTION
The [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/configmap/#motivation) has this to say: A ConfigMap is not designed to hold large chunks of data. The data stored in a ConfigMap cannot exceed 1 MiB. If you need to store settings that are larger than this limit, you may want to consider mounting a volume or use a separate database or file service.

Add note as requested [here](https://github.com/projectsveltos/addon-controller/issues/428)