### PR TITLE
Fix error in the configuration file

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,11 +35,11 @@ nav:
   - Deep dive into Profiles: 'addons/profile.md'
 - Templates:
   - Helm charts and resources as templates: 'template/template.md'
-  - Example: Integration with Crossplane: 'template/crossplane.md'
-  - Example: Integration with External Secret Management: 'template/external_secret.md'
+  - Example Integration with Crossplane: 'template/crossplane.md'
+  - Example Integration with External Secret Management: 'template/external_secret.md'
   - Support for Carvel ytt: 'template/ytt_extension.md'
   - Support for Jsonnet: 'template/jsonnet_extension.md'
-  - Example: Integrate Sveltos with own controller: 'template/bring_your_own_controller.md'
+  - Example Integrate Sveltos with own controller: 'template/bring_your_own_controller.md'
 - Resource Deployment Order:
   - Resource Deployment Order with ClusterProfile: 'deployment_order/manifest_order.md'
   - ClusterProfile dependsOn field: 'deployment_order/depends_on.md'


### PR DESCRIPTION
Fixes below error

```
Error: MkDocs encountered an error parsing the configuration file: mapping values are not allowed here
```