### PR TITLE
Update documentation

### DIFF
--- a/docs/events/addon_event_deployment.md
+++ b/docs/events/addon_event_deployment.md
@@ -225,7 +225,7 @@ spec:
 Each EventBasedAddon instance: 
 
 1. References an [EventSource](addon_event_deployment.md#event-definition) (which defines what the event is);
-2. Has a sourceClusterSelector selecting one or more managed clusters;
+2. Has a _sourceClusterSelector_ selecting one or more managed clusters; [^1]
 3. Contains a list of add-ons to deploy (either referencing ConfigMaps/Secrets or Helm charts)
 
 For example, the below EventTrigger references the eventSource *sveltos-service* defined above.
@@ -452,3 +452,5 @@ kubectl get networkpolicy -A
 NAMESPACE   NAME                    POD-SELECTOR                          AGE
 default     front-my-service        app.kubernetes.io/name=MyApp          10m40s
 ```
+
+[^1]: EventTrigger can also reference a [_ClusterSet_](../features/set.md) to select one or more managed clusters.

--- a/docs/features/set.md
+++ b/docs/features/set.md
@@ -110,9 +110,7 @@ spec:
     repositoryName: kyverno
     repositoryURL: https://kyverno.github.io/kyverno/
   setRefs:
-  - apiVersion: lib.projectsveltos.io/v1alpha1
-    kind: ClusterSet
-    name: prod
+  - prod # name of the ClusterSet
 ```
 
 #### Sveltos Deploys Kyverno
@@ -133,9 +131,7 @@ spec:
     repositoryName: kyverno
     repositoryURL: https://kyverno.github.io/kyverno/
   setRefs:
-  - apiVersion: lib.projectsveltos.io/v1alpha1
-    kind: ClusterSet
-    name: prod
+  - prod
 status:
   matchingClusters:
   - apiVersion: lib.projectsveltos.io/v1alpha1
@@ -212,9 +208,7 @@ spec:
     repositoryName: kyverno
     repositoryURL: https://kyverno.github.io/kyverno/
   setRefs:
-  - apiVersion: lib.projectsveltos.io/v1alpha1
-    kind: ClusterSet
-    name: prod
+  - prod
 status:
   matchingClusters:
   - apiVersion: lib.projectsveltos.io/v1alpha1


### PR DESCRIPTION
When referencing a ClusterSet/Set only name needs to be specified. This PR updated documentation.

A note is also added to specify that EventTrigger can now also reference ClusterSet to select one or more managed clusters.