### PR TITLE
Set timeout for kustomize install

### DIFF
--- a/docs/getting_started/install/install.md
+++ b/docs/getting_started/install/install.md
@@ -60,7 +60,7 @@ $ helm list -n projectsveltos
 ## Kustomize Installation
 
 ```
-$ kustomize build  https://github.com/projectsveltos/sveltos.git//kustomize/base/\?ref\=main |kubectl apply -f -
+$ kustomize build https://github.com/projectsveltos/sveltos.git//kustomize/base\?timeout\=120\&ref\=main |kubectl apply -f -
 
 $ kubectl apply -f https://raw.githubusercontent.com/projectsveltos/sveltos/main/manifest/default-classifier.yaml
 ```
@@ -68,7 +68,7 @@ $ kubectl apply -f https://raw.githubusercontent.com/projectsveltos/sveltos/main
 If you do not want to have any Sveltos agent in any **managed cluster**, run the following commands:
 
 ```
-$ kustomize build https://github.com/projectsveltos/sveltos.git//kustomize/overlays/agentless-mode/\?ref=\main |kubectl apply -f -
+$ kustomize build https://github.com/projectsveltos/sveltos.git//kustomize/overlays/agentless-mode\?timeout\=120\&ref\=main |kubectl apply -f -
 
 $ kubectl apply -f https://raw.githubusercontent.com/projectsveltos/sveltos/main/manifest/default-classifier.yaml
 ```


### PR DESCRIPTION
This is done so that kustomize install will not timeout that easily if you have a slow connection. The reason for the higher timeout is due to how `kustomize build` works. Kustomize will do a `git fetch` on the entire repository, which ofc, can take a while.