### PR TITLE
Complete unqualified image names

### DIFF
--- a/docs/features/configuration_drift.md
+++ b/docs/features/configuration_drift.md
@@ -102,7 +102,7 @@ data:
         spec:
           containers:
           - name: manager
-            image: projectsveltos/drift-detection-manager:dev
+            image: docker.io/projectsveltos/drift-detection-manager:dev
             resources:
               requests:
                 memory: 256Mi

--- a/kustomize/base/access-manager.yaml
+++ b/kustomize/base/access-manager.yaml
@@ -266,7 +266,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/access-manager:main
+        image: docker.io/projectsveltos/access-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/kustomize/base/addon-controller.yaml
+++ b/kustomize/base/addon-controller.yaml
@@ -681,7 +681,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: projectsveltos/addon-controller:main
+        image: docker.io/projectsveltos/addon-controller:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/kustomize/base/classifier.yaml
+++ b/kustomize/base/classifier.yaml
@@ -194,7 +194,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: projectsveltos/classifier:main
+        image: docker.io/projectsveltos/classifier:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/kustomize/base/conversion-webhook.yaml
+++ b/kustomize/base/conversion-webhook.yaml
@@ -36,7 +36,7 @@ spec:
       containers:
       - command:
         - /conversion-webhook
-        image: projectsveltos/webhook-conversion:main
+        image: docker.io/projectsveltos/webhook-conversion:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/kustomize/base/event-manager.yaml
+++ b/kustomize/base/event-manager.yaml
@@ -264,7 +264,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/event-manager:main
+        image: docker.io/projectsveltos/event-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/kustomize/base/healthcheck-manager.yaml
+++ b/kustomize/base/healthcheck-manager.yaml
@@ -218,7 +218,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/healthcheck-manager:main
+        image: docker.io/projectsveltos/healthcheck-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/kustomize/base/register-mgmt-cluster.yaml
+++ b/kustomize/base/register-mgmt-cluster.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
       - args:
         - --labels=
-        image: projectsveltos/register-mgmt-cluster:main
+        image: docker.io/projectsveltos/register-mgmt-cluster:main
         imagePullPolicy: IfNotPresent
         name: register-mgmt-cluster
         resources:

--- a/kustomize/base/shard-controller.yaml
+++ b/kustomize/base/shard-controller.yaml
@@ -146,7 +146,7 @@ spec:
         - --report-mode=0
         command:
         - /manager
-        image: projectsveltos/shard-controller:main
+        image: docker.io/projectsveltos/shard-controller:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/kustomize/base/sveltoscluster-manager.yaml
+++ b/kustomize/base/sveltoscluster-manager.yaml
@@ -98,7 +98,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/sveltoscluster-manager:main
+        image: docker.io/projectsveltos/sveltoscluster-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/agents_in_mgmt_cluster_manifest.yaml
+++ b/manifest/agents_in_mgmt_cluster_manifest.yaml
@@ -14323,7 +14323,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: projectsveltos/addon-controller:main
+        image: docker.io/projectsveltos/addon-controller:main
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -14654,7 +14654,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/access-manager:main
+        image: docker.io/projectsveltos/access-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -14796,7 +14796,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/sveltoscluster-manager:main
+        image: docker.io/projectsveltos/sveltoscluster-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -15058,7 +15058,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/healthcheck-manager:main
+        image: docker.io/projectsveltos/healthcheck-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -17410,7 +17410,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/event-manager:main
+        image: docker.io/projectsveltos/event-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -17649,7 +17649,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: projectsveltos/classifier:main
+        image: docker.io/projectsveltos/classifier:main
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -18032,7 +18032,7 @@ spec:
         - --agent-in-mgmt-cluster
         command:
         - /manager
-        image: projectsveltos/shard-controller:main
+        image: docker.io/projectsveltos/shard-controller:main
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -18105,7 +18105,7 @@ spec:
       containers:
       - args:
         - --labels=
-        image: projectsveltos/register-mgmt-cluster:main
+        image: docker.io/projectsveltos/register-mgmt-cluster:main
         imagePullPolicy: IfNotPresent
         name: register-mgmt-cluster
         resources:
@@ -18158,7 +18158,7 @@ spec:
       containers:
       - command:
         - /conversion-webhook
-        image: projectsveltos/webhook-conversion:main
+        image: docker.io/projectsveltos/webhook-conversion:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -14289,7 +14289,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: projectsveltos/addon-controller:main
+        image: docker.io/projectsveltos/addon-controller:main
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -14620,7 +14620,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/access-manager:main
+        image: docker.io/projectsveltos/access-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -14762,7 +14762,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/sveltoscluster-manager:main
+        image: docker.io/projectsveltos/sveltoscluster-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -15024,7 +15024,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/healthcheck-manager:main
+        image: docker.io/projectsveltos/healthcheck-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -17376,7 +17376,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/event-manager:main
+        image: docker.io/projectsveltos/event-manager:main
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -17614,7 +17614,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: projectsveltos/classifier:main
+        image: docker.io/projectsveltos/classifier:main
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -17804,7 +17804,7 @@ spec:
         - --report-mode=0
         command:
         - /manager
-        image: projectsveltos/shard-controller:main
+        image: docker.io/projectsveltos/shard-controller:main
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -17877,7 +17877,7 @@ spec:
       containers:
       - args:
         - --labels=
-        image: projectsveltos/register-mgmt-cluster:main
+        image: docker.io/projectsveltos/register-mgmt-cluster:main
         imagePullPolicy: IfNotPresent
         name: register-mgmt-cluster
         resources:
@@ -17930,7 +17930,7 @@ spec:
       containers:
       - command:
         - /conversion-webhook
-        image: projectsveltos/webhook-conversion:main
+        image: docker.io/projectsveltos/webhook-conversion:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/sveltosctl_manifest.yaml
+++ b/manifest/sveltosctl_manifest.yaml
@@ -46,7 +46,7 @@ spec:
       serviceAccountName: sveltosctl
       containers:
       - name: sveltosctl
-        image: projectsveltos/sveltosctl:main
+        image: docker.io/projectsveltos/sveltosctl:main
         imagePullPolicy: IfNotPresent
         command:
           - /sveltosctl


### PR DESCRIPTION
Add 'docker.io' registry server name where missing.

That allows the applications to run on CRIs not configured to handle unqualified registries.