### PR TITLE
Update docs for Patch ConfigMaps

### DIFF
--- a/docs/getting_started/install/air_gapped_installation.md
+++ b/docs/getting_started/install/air_gapped_installation.md
@@ -9,6 +9,7 @@ tags:
     - multi-tenancy
 authors:
     - Eleni Grosdouli
+    - Robin Afflerbach
 ---
 
 ## What is Sveltos?
@@ -17,98 +18,75 @@ Sveltos is a set of Kubernetes controllers deployed in the management cluster. F
 
 ## Air-Gapped Installation
 
+!!! note
+    This documentation assumes that Sveltos is installed using `Helm`.
+
 Sveltos can be installed in an **air-gapped** environment. An air-gapped environment is a **highly secure** environment completely **cut off** from the **Internet** and any other external networks. That implies, getting the required Sveltos images from the `Docker Hub` is not possible.
 
-When installing Sveltos using the official `Helm chart`, the *drift-detection-manager* and the *sveltos-agent* will be deployed in each managed cluster. However, in an air-gapped environment, additional steps are required before installation.
+This method can also be useful if the cluster runs in an environment where access to certain image registries is restricted and a custom registry or registry cache needs to be used (e.g. in large enterprises).
+
+When installing Sveltos using the official `Helm chart`, the *drift-detection-manager* and the *sveltos-agent* will be deployed in each managed cluster or on the management cluster when `agent.managementCluster=true` is set. However, in restricted environments, additional values are required for the installation.
+
+The *drift-detection-manager* and the *sveltos-agent* deployments will be dynamically deployed instead of from the Sveltos installation directly. This means that the patches to these deployments are done during runtime instead of upfront.
+
+There are two types of patches that can be applied:
+- [Strategic Merge Patch](http://kubernetes.io/docs/tasks/manage-kubernetes-objects/update-api-object-kubectl-patch/)
+- [JSON Patch (RFC6902)](https://datatracker.ietf.org/doc/html/rfc6902)
+
+Patches of both types can be persisted in a `ConfigMap` and passed to the components that will deploy the *drift-detection-manager* and the *sveltos-agent* respectively.
+
+The `Helm` chart offers a way to only specify the patches and the `ConfigMaps` will be created automatically so that they will be applied to the deployments before applying the *drift-detection-manager* and *sveltos-agent*.
 
 ## drift-detection-manager Configuration
 
-Before installing Sveltos in a Kubernetes **management** cluster, **create** and **apply** the below `ConfigMap` resource. The `ConfigMap` will get deployed in the `projectsveltos` namespace and holds the information that gets applied to the *drift-detection-manager* before deployment to the Kubernetes **managed** cluster.
+To customize the *drift-detection-manager* deployment you can add your patches to the `Helm` values like here:
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: drift-detection
-  namespace: projectsveltos
-data:
-  patch: |-
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      name: drift-detection-manager
-    spec:
-      template:
+...
+addonController:
+  driftDetectionManagerPatchConfigMap:
+    data:
+      patch: |-
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: drift-detection-manager
         spec:
-          imagePullSecrets:
-            - name: my-registry-secret
-          containers:
-            - name: manager
-              image: registry.company.io/projectsveltos/drift-detection-manager:dev
+          template:
+            spec:
+              imagePullSecrets:
+                - name: my-registry-secret
+              containers:
+                - name: manager
+                  image: registry.company.io/projectsveltos/drift-detection-manager:dev
+...
 ```
+
+This example makes use of the `Strategic Merge Patch`. The key of the `data` in the `ConfigMap` (here `patch`) is arbitrary and can be changed to any other value.
 
 The *drift-detection-manager* image is located [here](https://hubgw.docker.com/layers/projectsveltos/drift-detection-manager/dev/images/sha256-d31b3d57ee446ab216d7b925f35ef3da50de5161dff17ce2ef7c35f5bdd9c539).
 
-!!! tip
-    Replace the `image: registry.company.io/projectsveltos/drift-detection-manager:dev` argument with your private registry details.
-
-Apart from deploying the `ConfigMap` resource in the **management** cluster, the argument `--drift-detection-config=drift-detection` needs to be included in the `addon-controller` of the ProjectSveltos `Helm chart`. The official `Helm chart` values are located [here](https://github.com/projectsveltos/helm-charts/blob/main/charts/projectsveltos/values.yaml).
-
-```yaml hl_lines="9"
-addonController:
-  controller:
-    args:
-    - --diagnostics-address=:8443
-    - --report-mode=0
-    - --shard-key=
-    - --v=5
-    - --version=v0.46.1
-    - --drift-detection-config=drift-detection
-```
-
-or, if running in agentless mode:
-
-```yaml hl_lines="10"
-addonController:
-  controller:
-    argsAgentMgmtCluster:
-    - --diagnostics-address=:8443
-    - --report-mode=0
-    - --agent-in-mgmt-cluster
-    - --shard-key=
-    - --v=5
-    - --version=v0.46.1
-    - --drift-detection-config=drift-detection
-```
-
-!!! note
-    `drift-detection` is the name of the `ConfigMap` resource applied in an earlier section.
-
 ## sveltos-agent Configuration
 
-We will follow the same approach described above for the *sveltos-agent*. **Create** and **apply** the below `ConfigMap` resource in the Kubernetes **management** cluster and update the ProjectSveltos `Helm chart` values.
+The *sveltos-agent* can be patched in the same way. In order to edit the deployment the following values can be used:
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: sveltos-agent-config
-  namespace: projectsveltos
-data:
-  patch: |-
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      name: sveltos-agent-manager
-    spec:
-      template:
-        spec:
-          imagePullSecrets:
+...
+classifierManager:
+  agentPatchConfigMap:
+    data:
+      image-patch: |-
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: registry.company.io/projectsveltos/sveltos-agent:dev
+        - op: add
+          path: /spec/template/spec/imagePullSecrets
+          value:
             - name: my-registry-secret
-          containers:
-            - name: manager
-              image: registry.company.io/projectsveltos/sveltos-agent:dev
+...
 ```
+
+This example makes use of `JSON Patch (RFC 6902)` to change deployment values. It's not limited to only one item in `data`.
 
 The *sveltos-agent* **image** is located [here](https://hubgw.docker.com/layers/projectsveltos/sveltos-agent/dev/images/sha256-d2c23f55e4585e9cfd103547bd238aef42f8cedb1d8ca23600bd393710669b37).
 
@@ -116,47 +94,18 @@ The *sveltos-agent* will be deployed in the **management** cluster with the bell
 
 - **Custom image from private registry**: registry.company.io/projectsveltos/sveltos-agent:dev
 - **Private registry credentials**: my-registry-secret (the secret must be present in the **projectsveltos** namespace)[ˆ1]
-- **Proxy settings**: HTTP_PROXY, HTTPS_PROXY, and NO_PROXY defined.
 
 !!! tip
     Replace the `image: registry.company.io/projectsveltos/sveltos-agent:dev` argument with your private registry details.
 
     To create the `my-registry-secret` Secret, provide your credentials directly using the command: ```kubectl create secret docker-registry my-registry-secret -n projectsveltos --docker-server=<your-registry-server> --docker-username=<your-name> --docker-password=<your-pword> --docker-email=<your-email>```
 
-Include the argument `--sveltos-agent-config=sveltos-agent-config` to the `classifer-manager` deployment within the Helm chart values.
-
-```yaml hl_lines="8"
-classifierManager:
-  manager:
-    args:
-    - --diagnostics-address=:8443
-    - --report-mode=0
-    - --shard-key=
-    - --v=5
-    - --version=v0.46.1
-```
-
-or, if running in agentless mode:
-
-```yaml hl_lines="10"
-classifierManager:
-  manager:
-    argsAgentMgmtCluster:
-    - --diagnostics-address=:8443
-    - --report-mode=0
-    - --agent-in-mgmt-cluster
-    - --shard-key=
-    - --v=5
-    - --version=v0.46.1    
-    - --sveltos-agent-config=sveltos-agent-config
-```
-
 ## Helm Installation
 
 On the Kubernetes **management** cluster, install ProjectSveltos!
 
 ```
-$ helm repo add projectsveltos  <private-repo-url>
+$ helm repo add projectsveltos <private-repo-url>
 
 $ helm repo update
 

--- a/docs/getting_started/install/install.md
+++ b/docs/getting_started/install/install.md
@@ -9,6 +9,7 @@ tags:
     - multi-tenancy
 authors:
     - Gianluca Mardente
+    - Robin Afflerbach
 ---
 
 ## What is Sveltos?
@@ -27,7 +28,7 @@ Sveltos supports two modes: **Mode 1** and **Mode 2**.
 
 To install Sveltos in mode 1, run the commands below.
 
-```
+```sh
 $ kubectl apply -f https://raw.githubusercontent.com/projectsveltos/sveltos/main/manifest/manifest.yaml
 
 $ kubectl apply -f https://raw.githubusercontent.com/projectsveltos/sveltos/main/manifest/default-instances.yaml
@@ -37,7 +38,7 @@ $ kubectl apply -f https://raw.githubusercontent.com/projectsveltos/sveltos/main
 
 If you do not want to have any Sveltos agent in any **managed cluster**, run the commands below.
 
-```
+```sh
 $ kubectl apply -f https://raw.githubusercontent.com/projectsveltos/sveltos/main/manifest/agents_in_mgmt_cluster_manifest.yaml
 
 $ kubectl apply -f https://raw.githubusercontent.com/projectsveltos/sveltos/main/manifest/default-instances.yaml
@@ -60,27 +61,39 @@ Sveltos can be installed as a Helm chart or with Kustomize. By default, **Mode 1
 
 ### Helm Installation
 
-```
+!!! note
+    When deploying Sveltos with Helm, the `helm upgrade` command won't automatically update Sveltos's Custom Resource Definitions (CRDs). To ensure CRDs are updated, run this command before upgrading Sveltos.
+    ```sh
+    kubectl apply -f https://raw.githubusercontent.com/projectsveltos/sveltos/main/manifest/crds/sveltos_crds.yaml
+    ```
+
+```sh
 $ helm repo add projectsveltos https://projectsveltos.github.io/helm-charts
 
 $ helm repo update
+```
 
+#### Mode 1: Local Agent Mode
+
+```sh
 $ helm install projectsveltos projectsveltos/projectsveltos -n projectsveltos --create-namespace
 
 $ helm list -n projectsveltos
 ```
 
-!!! note
-    When deploying Sveltos with Helm, the `helm upgrade` command won't automatically update Sveltos's Custom Resource Definitions (CRDs). To ensure CRDs are updated, run this command before upgrading Sveltos.
-    ```bash
-    kubectl apply -f https://raw.githubusercontent.com/projectsveltos/sveltos/main/manifest/crds/sveltos_crds.yaml
-    ```
+#### Mode 2: Centralised Agent Mode
+
+```sh
+$ helm install projectsveltos projectsveltos/projectsveltos -n projectsveltos --create-namespace --set agent.managementCluster=true
+
+$ helm list -n projectsveltos
+```
 
 ### Kustomize Installation
 
 #### Mode 1: Local Agent Mode
 
-```
+```sh
 $ kustomize build https://github.com/projectsveltos/sveltos.git//kustomize/base\?timeout\=120\&ref\=main |kubectl apply -f -
 
 $ kubectl apply -f https://raw.githubusercontent.com/projectsveltos/sveltos/main/manifest/default-instances.yaml
@@ -88,7 +101,7 @@ $ kubectl apply -f https://raw.githubusercontent.com/projectsveltos/sveltos/main
 
 #### Mode 2: Centralised Agent Mode
 
-```
+```sh
 $ kustomize build https://github.com/projectsveltos/sveltos.git//kustomize/overlays/agentless-mode\?timeout\=120\&ref\=main |kubectl apply -f -
 
 $ kubectl apply -f https://raw.githubusercontent.com/projectsveltos/sveltos/main/manifest/default-instances.yaml


### PR DESCRIPTION
## Description

This PR mainly changes the air gapped installation so that the user can use some helm values instead of creating config maps and manually reference them in arguments passed to binaries. The required feature has been implemented [here](https://github.com/projectsveltos/helm-charts/pull/89).

Additionally I fixed a missing argument and described how to install Sveltos with helm with agents running on the management cluster, which was missing in the installation guide.