### PR TITLE
Fix annotation

### DIFF
--- a/docs/template/external_secret.md
+++ b/docs/template/external_secret.md
@@ -145,7 +145,7 @@ Now we can configure Sveltos to distribute such content to all managed clusters 
       name: info
       namespace: default
       annotations:
-        projectsveltos.io/instantiate: ok  # add annotation to indicate Sveltos content is a template
+        projectsveltos.io/template: ok  # add annotation to indicate Sveltos content is a template
     type: addons.projectsveltos.io/cluster-profile
     stringData:
       secret.yaml: |


### PR DESCRIPTION
When ClusterProfile points a ConfigMap/Secret whose content is a template, the annotation to be used is `projectsveltos.io/template`