### PR TITLE
adds NATS configuration documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,9 @@ markdown_extensions:
     custom_fences:
     - name: mermaid
       class: mermaid
-      format: !!python/name:pymdownx.superfences.fence_code_format    
+      format: !!python/name:pymdownx.superfences.fence_code_format
+- pymdownx.tabbed:
+    alternate_style: true
 - pymdownx.inlinehilite
 - pymdownx.snippets
 - pymdownx.emoji:


### PR DESCRIPTION
This PR adds documentation outlining the full list of options for connecting Sveltos to a NATS cluster. 

Fixes #572 