### PR TITLE
SveltosCluster registration

### DIFF
--- a/docs/register/register-cluster.md
+++ b/docs/register/register-cluster.md
@@ -226,7 +226,7 @@ By default, Sveltos searches for a `Secret` named `<cluster-name>-sveltos-kubeco
     kind: Secret
     metadata:
       name: YOUR-CLUSTER-NAME-sveltos-kubeconfig
-      namespace: YOUR NAMESPACE
+      namespace: YOUR-CLUSTER-NAMESPACE
     data:
       kubeconfig: BASE64 ENCODED kubeconfig
     type: Opaque


### PR DESCRIPTION
SveltosCluster and the Secret instance must be in the same namespace. Documentation was unclear about that. Fixing that.

Fixes #588 