### PR TITLE
(feat) Event framework and templating

### DIFF
--- a/docs/addons/clusterprofile.md
+++ b/docs/addons/clusterprofile.md
@@ -16,6 +16,10 @@ authors:
 
 [ClusterProfile](https://github.com/projectsveltos/sveltos-manager/blob/main/api/v1beta1/clusterprofile_types.go "ClusterProfile to manage Kubernetes add-ons") is the CustomerResourceDefinition used to instruct Sveltos which add-ons to deploy on a set of clusters.
 
+### Pause Annotation
+
+Pausing a ClusterProfile with the `profile.projectsveltos.io/paused` annotation prevents Sveltos from performing any reconciliation. This effectively freezes the ClusterProfile in its current state, ensuring that no changes are applied to the clusters it manages.
+
 ### Spec.ClusterSelector
 
 *clusterSelector* field is used to specify which managed clusters should receive the add-ons and applications defined in the configuration.

--- a/docs/addons/example_flux_sources.md
+++ b/docs/addons/example_flux_sources.md
@@ -258,7 +258,7 @@ Let's try it out! The content in the "template" directory of the [repository](ht
 ### GitRepository Definition
 
 !!! note
-    Add the __projectsveltos.io/template: "true"__ annotation to the __GitRepository__ resources created further above.
+    Add the __projectsveltos.io/template: ok__ annotation to the __GitRepository__ resources created further above.
 
 !!! example "GitRepository Resource"
     ```yaml
@@ -269,7 +269,7 @@ Let's try it out! The content in the "template" directory of the [repository](ht
       name: flux-system
       namespace: flux-system
       annotations:
-        projectsveltos.io/template: "true"
+        projectsveltos.io/template: ok
     spec:
       interval: 1m0s
       ref:

--- a/docs/addons/profile.md
+++ b/docs/addons/profile.md
@@ -18,6 +18,10 @@ authors:
 
 Profile is a namespace-scoped resource.  It can only match clusters and reference resources within its own namespace.
 
+### Pause Annotation
+
+Pausing a ClusterProfile with the `profile.projectsveltos.io/paused` annotation prevents Sveltos from performing any reconciliation. This effectively freezes the ClusterProfile in its current state, ensuring that no changes are applied to the clusters it manages.
+
 ### Spec.ClusterSelector
 
 *clusterSelector* field is used to specify which managed clusters should receive the add-ons and applications defined in the configuration.

--- a/docs/events/examples/loadbalancer.md
+++ b/docs/events/examples/loadbalancer.md
@@ -101,7 +101,7 @@ metadata:
   name: loadbalancer-class-handler-svc
   namespace: projectsveltos
   annotations:
-    projectsveltos.io/instantiate: "true"
+    projectsveltos.io/instantiate: ok
 data:
   service.yaml: |
     kind: Service
@@ -133,7 +133,7 @@ metadata:
   name: loadbalancer-class-handler-cp
   namespace: projectsveltos
   annotations:
-    projectsveltos.io/instantiate: "true"
+    projectsveltos.io/instantiate: ok
 data:
   cp.yaml: |
     apiVersion: config.projectsveltos.io/v1beta1
@@ -312,7 +312,7 @@ metadata:
   name: loadbalancer-class-handler-status
   namespace: projectsveltos
   annotations:
-    projectsveltos.io/template: "true"
+    projectsveltos.io/template: ok
     projectsveltos.io/subressources: "status"
 data:
   service.yaml: |
@@ -386,7 +386,7 @@ metadata:
   name: loadbalancer-class-handler-svc
   namespace: projectsveltos
   annotations:
-    projectsveltos.io/instantiate: "true"
+    projectsveltos.io/instantiate: ok
 data:
   service.yaml: |
     kind: Service
@@ -418,7 +418,7 @@ metadata:
   name: loadbalancer-class-handler-cp
   namespace: projectsveltos
   annotations:
-    projectsveltos.io/instantiate: "true"
+    projectsveltos.io/instantiate: ok
 data:
   cp.yaml: |
     apiVersion: config.projectsveltos.io/v1beta1
@@ -453,7 +453,7 @@ metadata:
   name: loadbalancer-class-handler-status
   namespace: projectsveltos
   annotations:
-    projectsveltos.io/template: "true"
+    projectsveltos.io/template: ok
     projectsveltos.io/subressources: "status"
 data:
   service.yaml: |

--- a/docs/events/examples/otel.md
+++ b/docs/events/examples/otel.md
@@ -123,7 +123,7 @@ Once we have a matching namespace, the `EventTrigger` performs the following act
       name: cluster-receiver-value
       namespace: default
       annotations:
-        projectsveltos.io/instantiate: "true"
+        projectsveltos.io/instantiate: ok
     data:
       cluster-receiver-value.yaml: |
           clusterReceiver:

--- a/docs/events/examples/secrets_on_demand.md
+++ b/docs/events/examples/secrets_on_demand.md
@@ -88,7 +88,7 @@ The `EventTrigger` will then generate a Sveltos `ClusterProfile`. The ClusterPro
       name: namespaces
       namespace: default
       annotations: # This annotation indicates Sveltos to instantiate it using Event data, i.e, the namespaces requiring the credentials
-        projectsveltos.io/instantiate: "true"
+        projectsveltos.io/instantiate: ok
     data:
       namespaces: |
         {{- range $v := .MatchingResources }}
@@ -101,7 +101,7 @@ The `EventTrigger` will then generate a Sveltos `ClusterProfile`. The ClusterPro
       name: info
       namespace: default
       annotations: # This annotation indicates Sveltos the content is a template that needs to be instantiated using resources fetched in TemplateResourceRefs
-        projectsveltos.io/template: "true"
+        projectsveltos.io/template: ok
     data:
       secret.yaml: |
         {{ $namespaces := ( ( index (getResource "Namespaces").data "namespaces" ) | fromYaml ) }}

--- a/docs/getting_started/install/air_gapped_installation.md
+++ b/docs/getting_started/install/air_gapped_installation.md
@@ -146,7 +146,7 @@ Continue with the **sveltoctl** command-line interface (CLI) definition and inst
       name: info
       namespace: default
       annotations:
-        projectsveltos.io/template: "true"  # add annotation to indicate Sveltos content is a template
+        projectsveltos.io/template: ok  # add annotation to indicate Sveltos content is a template
     data:
       secret.yaml: |
         {{ copy "ImagePullSecret" }}

--- a/docs/template/additional_template_info.md
+++ b/docs/template/additional_template_info.md
@@ -67,7 +67,7 @@ When incorporating Go template logic into Sveltos templates, utilise the **escap
       name: meilisearch-proxy-secrets
       namespace: default
       annotations:
-        projectsveltos.io/template: "true"
+        projectsveltos.io/template: ok
     data:
       secrets.yaml: |
         {{ $cluster := .Cluster.metadata.name }}

--- a/docs/template/bring_your_own_controller.md
+++ b/docs/template/bring_your_own_controller.md
@@ -103,7 +103,7 @@ The following YAML instructions are used to deploy add-ons using Sveltos:
       name: bucket
       namespace: default
       annotations:
-        projectsveltos.io/template: "true"
+        projectsveltos.io/template: ok
     data:
       bucket.yaml: |
         apiVersion: demo.projectsveltos.io/v1alpha1
@@ -122,7 +122,7 @@ The following YAML instructions are used to deploy add-ons using Sveltos:
       name: uploader
       namespace: default
       annotations:
-        projectsveltos.io/template: "true"
+        projectsveltos.io/template: ok
     data:
       secret.yaml: |
         apiVersion: v1

--- a/docs/template/crossplane.md
+++ b/docs/template/crossplane.md
@@ -66,7 +66,7 @@ Once the Pod is deployed, it will upload a file to the `my-bucket` bucket.
       name: bucket
       namespace: default
       annotations:
-        projectsveltos.io/template: "true"
+        projectsveltos.io/template: ok
     data:
       bucket.yaml: |
         apiVersion: storage.gcp.upbound.io/v1beta1
@@ -89,7 +89,7 @@ Once the Pod is deployed, it will upload a file to the `my-bucket` bucket.
       name: uploader
       namespace: default
       annotations:
-        projectsveltos.io/template: "true"
+        projectsveltos.io/template: ok
     data:
       secret.yaml: |
         apiVersion: v1

--- a/docs/template/example_multicluster_iteration_template.md
+++ b/docs/template/example_multicluster_iteration_template.md
@@ -124,7 +124,7 @@ Lets assume the clusters where the service should get deployed has the cluster l
       name: nats-services
       namespace: default
       annotations:
-          projectsveltos.io/template: "true"
+          projectsveltos.io/template: ok
     data:
       services.yaml: |
         {{ range $cluster := (getResource "ClusterData").spec.matchingResources }}

--- a/docs/template/examples.md
+++ b/docs/template/examples.md
@@ -68,7 +68,7 @@ To simply copy the Secret grabbed from the management cluster to any matching ma
       name: info
       namespace: default
       annotations:
-        projectsveltos.io/template: "true"  # add annotation to indicate Sveltos content is a template
+        projectsveltos.io/template: ok  # add annotation to indicate Sveltos content is a template
     data:
       secret.yaml: |
         {{ copy "ExternalSecret" }}
@@ -144,7 +144,7 @@ spec:
       name: info
       namespace: default
       annotations:
-        projectsveltos.io/template: "true"  # add annotation to indicate Sveltos content is a template
+        projectsveltos.io/template: ok  # add annotation to indicate Sveltos content is a template
     data:
       secret.yaml: |
         {{ setField "NginxDeployment" "spec.replicas" (int64 5) }}
@@ -165,7 +165,7 @@ Consequently, each managed cluster will have the deployment running with 5 repli
       name: info
       namespace: default
       annotations:
-        projectsveltos.io/template: "true"  # add annotation to indicate Sveltos content is a template
+        projectsveltos.io/template: ok  # add annotation to indicate Sveltos content is a template
     data:
       secret.yaml: |
         {{ removeField "NginxDeployment" "spec.replicas" }}
@@ -190,7 +190,7 @@ Building upon the previous example, this section explores how to manipulate vari
       name: info
       namespace: default
       annotations:
-        projectsveltos.io/template: "true"  # add annotation to indicate Sveltos content is a template
+        projectsveltos.io/template: ok  # add annotation to indicate Sveltos content is a template
     data:
       secret.yaml: |
         {{ $depl := (getResource "NginxDeployment") }}
@@ -220,7 +220,7 @@ The example demonstrates a more complex scenario where the template modifies the
       name: info
       namespace: default
       annotations:
-        projectsveltos.io/template: "true"  # add annotation to indicate Sveltos content is a template
+        projectsveltos.io/template: ok  # add annotation to indicate Sveltos content is a template
     data:
       secret.yaml: |
         {{ $currentContainers := (getField "NginxDeployment" "spec.template.spec.containers") }}

--- a/docs/template/jsonnet_extension.md
+++ b/docs/template/jsonnet_extension.md
@@ -85,7 +85,7 @@ At this point, you can use the Sveltos' [template](template_generic_examples.md)
       name: jsonnet-resources
       namespace: default
       annotations:
-        projectsveltos.io/template: "true"  # add annotation to indicate Sveltos content is a template
+        projectsveltos.io/template: ok  # add annotation to indicate Sveltos content is a template
     data:
       resource.yaml: |
         {{ (getResource "JsonnetSource").status.resources }}

--- a/docs/template/template_generic_examples.md
+++ b/docs/template/template_generic_examples.md
@@ -262,7 +262,7 @@ The below YAML definition instruct Sveltos to find a Secret named _autoscaler_ i
         namespace: default
     ```
 
-By adding the special annotation (`projectsveltos.io/template: "true"`) to a ConfigMap named _info_ (also in the _default_ namespace), we can define a template within it. Find the example template below.
+By adding the special annotation (`projectsveltos.io/template: ok`) to a ConfigMap named _info_ (also in the _default_ namespace), we can define a template within it. Find the example template below.
 
 !!! example "Example - ConfigMap Definition"
     ```yaml
@@ -273,7 +273,7 @@ By adding the special annotation (`projectsveltos.io/template: "true"`) to a Con
       name: info
       namespace: default
       annotations:
-        projectsveltos.io/template: "true"  # add annotation to indicate Sveltos content is a template
+        projectsveltos.io/template: ok  # add annotation to indicate Sveltos content is a template
     data:
       secret.yaml: |
         # AutoscalerSecret now references the Secret default/autoscaler
@@ -338,13 +338,13 @@ Firstly, we create a `ConfigMap` named _replicate-external-secret-operator-secre
       name: replicate-external-secret-operator-secret
       namespace: default
       annotations:
-        projectsveltos.io/template: "true"  # add annotation to indicate Sveltos content is a template
+        projectsveltos.io/template: ok  # add annotation to indicate Sveltos content is a template
     data:
       secret.yaml: |
         {{ copy "ESOSecret" }}
     ```
 
-- The `projectsveltos.io/template: "true"` annotation tells Sveltos this is a template
+- The `projectsveltos.io/template: ok` annotation tells Sveltos this is a template
 - The template references a placeholder named _ESOSecret_, which will be filled with the actual secret data later
 
 Next, we will define a `ClusterProfile` named _replicate-external-secret-operator-secret_. The profile instructs Sveltos on how to deploy the secrets:
@@ -425,7 +425,7 @@ We expose additional `InfrastructureProviderIdentity` and `InfrastructureProvide
       name: azure-cloud-provider
       namespace: default
       annotations:
-        projectsveltos.io/template: "true"
+        projectsveltos.io/template: ok
     data:
       configmap.yaml: |
         {{- $cluster := .InfrastructureProvider -}}

--- a/docs/template/ytt_extension.md
+++ b/docs/template/ytt_extension.md
@@ -77,7 +77,7 @@ At this point, you can use the Sveltos' [template](template_generic_examples.md)
       name: ytt-resources
       namespace: default
       annotations:
-        projectsveltos.io/template: "true"  # add annotation to indicate Sveltos content is a template
+        projectsveltos.io/template: ok  # add annotation to indicate Sveltos content is a template
     data:
       resource.yaml: |
         {{ (getResource "YttSource").status.resources }}

--- a/docs/use_cases/use_case_gitops.md
+++ b/docs/use_cases/use_case_gitops.md
@@ -46,7 +46,7 @@ Install and run Flux in the management cluster. Configure it to synchronise the 
       name: flux-system
       namespace: flux-system
       annotations:
-        projectsveltos.io/template: "true" # (1)
+        projectsveltos.io/template: ok # (1)
     spec:
       interval: 1m0s # (2)
       ref:
@@ -94,7 +94,7 @@ Define a Sveltos ClusterProfile referencing to the `flux-system` `GitRepository`
 Whenever there is a change in the Git repository, Sveltos will leverage the Kustomize SDK to retrieve a list of resources to deploy to any cluster matching the label selector `env=fv` in the `eng` namespace.
 
 !!! note
-    The GitRepository or Bucket content can also be a template. Sveltos will take the content of the files and instantiate them by the use of the data resources in the management cluster. For the templates deployment, we will have to ensure the `GitRepository` Kubernetes resource includes the `projectsveltos.io/template: "true"` annotation.
+    The GitRepository or Bucket content can also be a template. Sveltos will take the content of the files and instantiate them by the use of the data resources in the management cluster. For the templates deployment, we will have to ensure the `GitRepository` Kubernetes resource includes the `projectsveltos.io/template: ok` annotation.
 
 ## More Resources
 


### PR DESCRIPTION
This PR cover new features added in this area:

1. name of the generated ClusterProfile names
2. new tenplate functions available in the event framework templating

This PR also adds a section explaining how to pause ClusterProfile/Profile instances

While value is not important, this PR also makes sure across all documentation we always use 
`projectsveltos.io/template: ok` and `projectsveltos.io/instantiate: ok`

Fixes #628 
Fixes #627 