### PR TITLE
Feature/rancher registering

### DIFF
--- a/docs/register/register-cluster.md
+++ b/docs/register/register-cluster.md
@@ -133,7 +133,7 @@ $ sveltosctl register cluster \
     If you use a kubeconfig downloaded from Rancher upstream cluster it will expire in 30 days ( this is by default if expiration time is not modified ). 
     To overcome this limit can be enabled token-renewal feature to continue managing downstream clusters without interruptions.
 
-    After enabling token-renewal on cluster-profiles, it must be also enabled JWT Authentication on Rancher upstream cluster for managed downstream clusters to allow dedicated serviceaccount authentication [JWT Authentication on Rancher](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/jwt-authentication).
+    After enabling token-renewal feature on cluster-profiles, it must be also enabled JWT Authentication on Rancher upstream cluster for managed downstream clusters to allow dedicated serviceaccount authentication [JWT Authentication on Rancher](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/jwt-authentication).
     
 ??? example "Civo"
     If you use [Civo Cloud](https://www.civo.com), simply download the cluster Kubeconfig and perform the below.


### PR DESCRIPTION
With this PR I want to contribute with a specific configuration I've tested using Rancher architecture with upstream and downstream clusters.

https://ranchermanager.docs.rancher.com/reference-guides/rancher-manager-architecture/communicating-with-downstream-user-clusters

The connection with Sveltos to downstream clusters is performed through upstream cluster ( Rancher ) using a specific service account. To enable token-renewal feature it must also be enabled JWT authentication on Rancher