### PR TITLE
clarify event framework and document PreDeployChecks

### DIFF
--- a/docs/addons/clusterprofile.md
+++ b/docs/addons/clusterprofile.md
@@ -253,6 +253,15 @@ the required prerequisite profiles, and ensure they are deployed to the same clu
 
 *ContinueOnConflict* configures Sveltos' conflict resolution behavior. When true, Sveltos logs the conflicts but continues deploying the remaining resources. When false (default), Sveltos halts deployment at the first detected conflict. This can happen when another *profile* has already deployed the same resource.
 
+### Spec.PreDeployChecks
+
+The *preDeployChecks* field defines a set of checks that Sveltos must pass *before* deploying resources for a given feature. If any check fails, deployment is held and retried — no resources are applied until all checks pass.
+
+Common use cases include:
+
+1. Readiness Gates: Ensuring a required `StorageClass`, `CustomResourceDefinition`, or operator is present before deploying an application that depends on it.
+2. Capacity Validation: Verifying that sufficient quota or node capacity exists in the target cluster before rolling out a workload.
+
 ### Spec.PreDeleteChecks
 
 The *preDeleteChecks* field defines a set of safety checks that Sveltos must perform *before* it begins removing resources from a managed cluster. If any of these checks fail (i.e., the Lua script returns health = false), Sveltos will halt the deletion process and retry later.

--- a/docs/addons/profile.md
+++ b/docs/addons/profile.md
@@ -263,6 +263,15 @@ the required prerequisite profiles, and ensure they are deployed to the same clu
 
 *ContinueOnConflict* configures Sveltos' conflict resolution behavior. When true, Sveltos logs the conflicts but continues deploying the remaining resources. When false (default), Sveltos halts deployment at the first detected conflict. This can happen when another *profile* has already deployed the same resource.
 
+### Spec.PreDeployChecks
+
+The *preDeployChecks* field defines a set of checks that Sveltos must pass *before* deploying resources for a given feature. If any check fails, deployment is held and retried — no resources are applied until all checks pass.
+
+Common use cases include:
+
+1. Readiness Gates: Ensuring a required `StorageClass`, `CustomResourceDefinition`, or operator is present before deploying an application that depends on it.
+2. Capacity Validation: Verifying that sufficient quota or node capacity exists in the target cluster before rolling out a workload.
+
 ### Spec.PreDeleteChecks
 
 The *preDeleteChecks* field defines a set of safety checks that Sveltos must perform *before* it begins removing resources from a managed cluster. If any of these checks fail (i.e., the Lua script returns health = false), Sveltos will halt the deletion process and retry later.

--- a/docs/events/addon_event_deployment.md
+++ b/docs/events/addon_event_deployment.md
@@ -304,8 +304,11 @@ In a nutshell, the below flow is executed.
 
 The collectResources field in an EventSource (__default: false__) determines whether Kubernetes resources matching the EventSource should be collected and transmitted to the management cluster for template instantiation.
 
-- When collectResources is true: templates can directly reference the Resource, which is a full representation of the matched Kubernetes resource (e.g., a Service with the label sveltos:fv) from the managed cluster.
-- When collectResources is false: templates can access the MatchingResources, a corev1.ObjectReference providing essential metadata information about the matched resource (e.g., Service with the label sveltos:fv) without the complete resource details.
+- When `collectResources` is `true`: templates can directly reference `.Resource` (with `oneForEvent: true`) or `.Resources` (with `oneForEvent: false`), which are full representations of the matched Kubernetes resources from the managed cluster.
+- When `collectResources` is `false`: templates can access `.MatchingResource` (with `oneForEvent: true`) or `.MatchingResources` (with `oneForEvent: false`), a `corev1.ObjectReference` providing essential metadata — **apiVersion**, **kind**, **name**, **namespace** — without the complete resource details.
+
+!!! note
+    The variable name is **singular** (`.MatchingResource`, `.Resource`) when `oneForEvent: true`, and **plural** (`.MatchingResources`, `.Resources`) when `oneForEvent: false`. Using the wrong form will result in a template rendering error.
 
 Based on the example above, the below EventReport instance can be found in the management cluster.
 
@@ -362,7 +365,9 @@ default     front-another-service   app.kubernetes.io/name=MyApp-secure   8m40s
 default     front-my-service        app.kubernetes.io/name=MyApp          8m40s
 ```
 
-A possible example for OneForEvent false, is when the add-ons to deploy are not template. For instance if Kyverno needs to be deployed in any managed cluster where certain event happened.
+The key distinction is **cardinality**: `oneForEvent: true` creates one `ClusterProfile` per matching resource; `oneForEvent: false` creates one `ClusterProfile` that covers all matching resources at once. Both modes support templating — with `oneForEvent: false` the template receives `.MatchingResources` (a slice) instead of a single `.MatchingResource`. See [Templating when oneForEvent is false](./templating_all_resources_together.md) for a full example using `range .MatchingResources`.
+
+A simple use case for `oneForEvent: false` is deploying a fixed add-on (no per-resource templating needed) to any cluster where a certain event happened. For instance, installing Kyverno as soon as a matching resource is detected:
 
 !!! example ""
     ```yaml
@@ -387,7 +392,8 @@ A possible example for OneForEvent false, is when the add-ons to deploy are not 
         helmChartAction:  Install
     ```
 
-__Currently, it is not possible to change this field once set.__
+!!! warning
+    `oneForEvent` is **immutable** — it cannot be changed after the `EventTrigger` is created. Delete and recreate the resource if you need to switch modes.
 
 ### Cleanup
 

--- a/docs/events/aggregated_selection.md
+++ b/docs/events/aggregated_selection.md
@@ -64,7 +64,7 @@ spec:
 
         local deployments = {}
         local autoscalers = {}
-        local deploymentsWithNoAutoscaler = {}
+        local unusedAutoscalers = {}
 
         for _, resource in ipairs(resources) do
           local kind = resource.kind

--- a/docs/events/templating_all_resources_together.md
+++ b/docs/events/templating_all_resources_together.md
@@ -24,3 +24,119 @@ The following resources are available during template instantiation if the `Even
 | **Resources** | A list of the full Kubernetes resources that triggered the events. All of their fields are available for templating. | Only if `collectResource` is set to `true` in the `eventSource`. |
 | **CloudEvents** | A list of the raw CloudEvents that triggered the `EventTrigger`. | Only if the events were from NATS.io. |
 | **Cluster** | The `SveltosCluster` or CAPI Cluster instance where the events occurred. | Always available |
+
+## Example: Enforce a Default NetworkPolicy Across All Namespaces
+
+### Scenario
+
+A platform team wants every namespace in each managed cluster to have a default-deny ingress `NetworkPolicy`. Namespaces are created frequently by different teams. Creating one `ClusterProfile` per namespace (i.e. `oneForEvent: true`) would produce hundreds of `ClusterProfiles`. Instead, `oneForEvent: false` produces **one** `ClusterProfile` per cluster that covers all namespaces together and is automatically reconciled whenever the namespace list changes.
+
+### EventSource
+
+The `EventSource` watches every `Namespace` in the managed cluster. `collectResources: false` is sufficient — the template only needs each namespace's name, not the full `Namespace` object.
+
+!!! example "Example — EventSource"
+    ```yaml
+    apiVersion: lib.projectsveltos.io/v1beta1
+    kind: EventSource
+    metadata:
+      name: namespace-watcher
+    spec:
+      collectResources: false
+      resourceSelectors:
+        - group: ""
+          version: "v1"
+          kind: "Namespace"
+    ```
+
+To skip system namespaces, add a `evaluateCEL` rule to the selector:
+
+!!! example "Example — EventSource excluding system namespaces"
+    ```yaml
+    apiVersion: lib.projectsveltos.io/v1beta1
+    kind: EventSource
+    metadata:
+      name: namespace-watcher
+    spec:
+      collectResources: false
+      resourceSelectors:
+        - group: ""
+          version: "v1"
+          kind: "Namespace"
+          evaluateCEL:
+            - name: skip_system_namespaces
+              rule: >
+                !resource.metadata.name.startsWith("kube-") &&
+                resource.metadata.name != "projectsveltos"
+    ```
+
+### EventTrigger
+
+`oneForEvent: false` instructs Sveltos to create a **single** `ClusterProfile` that aggregates all matching namespaces.
+
+!!! example "Example — EventTrigger"
+    ```yaml
+    apiVersion: lib.projectsveltos.io/v1beta1
+    kind: EventTrigger
+    metadata:
+      name: namespace-networkpolicy-enforcer
+    spec:
+      sourceClusterSelector:
+        matchLabels:
+          env: production
+      eventSourceName: namespace-watcher
+      oneForEvent: false
+      policyRefs:
+        - name: default-deny-per-namespace
+          namespace: default
+          kind: ConfigMap
+    ```
+
+### ConfigMap — Template Using MatchingResources
+
+Because `oneForEvent: false`, the template receives `.MatchingResources` — a **slice** of `corev1.ObjectReference` values, one per namespace. Each entry exposes `.APIVersion`, `.Kind`, `.Namespace`, and `.Name`. For cluster-scoped resources like `Namespace`, `.Namespace` is empty and `.Name` is the namespace name.
+
+!!! example "Example — ConfigMap with range .MatchingResources"
+    ```yaml
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: default-deny-per-namespace
+      namespace: default
+      annotations:
+        projectsveltos.io/instantiate: ok
+    data:
+      networkpolicies.yaml: |
+        {{- range .MatchingResources }}
+        ---
+        apiVersion: networking.k8s.io/v1
+        kind: NetworkPolicy
+        metadata:
+          name: default-deny-ingress
+          namespace: {{ .Name }}
+        spec:
+          podSelector: {}
+          policyTypes:
+            - Ingress
+        {{- end }}
+    ```
+
+`{{- range .MatchingResources }}` iterates every namespace that matched the `EventSource`. For each entry, `{{ .Name }}` resolves to the namespace name. The rendered output is a single multi-document YAML applied by the one generated `ClusterProfile`.
+
+### What Happens at Runtime
+
+1. The Sveltos agent in each matching cluster detects all `Namespace` resources and reports them to the management cluster in a single `EventReport`.
+2. The event-manager creates **one** `ClusterProfile` because `oneForEvent: false`.
+3. Before deploying, the `ConfigMap` template is instantiated with the current `MatchingResources` slice: one `NetworkPolicy` block is rendered per namespace.
+4. When a new namespace is created, the `EventSource` fires again. Sveltos re-instantiates the template with the updated namespace list and reconciles — the new namespace's `NetworkPolicy` is added automatically.
+5. When a namespace is deleted, the same reconcile loop runs and the corresponding `NetworkPolicy` entry is removed from the rendered output. Sveltos withdraws it from the cluster.
+
+### oneForEvent: true vs. oneForEvent: false
+
+| | `oneForEvent: true` | `oneForEvent: false` |
+|---|---|---|
+| ClusterProfiles created | One per matching resource | One for all matching resources |
+| Template variable | `.MatchingResource` (single `ObjectReference`) | `.MatchingResources` (slice of `ObjectReference`) |
+| Full resource data | `.Resource` (if `collectResources: true`) | `.Resources` (if `collectResources: true`) |
+| Scales to 200 namespaces as | 200 ClusterProfiles | 1 ClusterProfile |
+| Good when | Each resource needs its own independent config | The same config is applied once, referencing all resources |

--- a/docs/features/pre_post_delete_checks.md
+++ b/docs/features/pre_post_delete_checks.md
@@ -9,8 +9,28 @@ authors:
     - Gianluca Mardente
 ---
 
-Sveltos provides a robust framework to ensure your managed clusters are in the correct state throughout the entire lifecycle of a resource—from initial deployment to final deletion. This is achieved through three types of checks: `ValidateHealthChecks`, `PreDeleteChecks`, and `PostDeleteChecks`.
+Sveltos provides a robust framework to ensure your managed clusters are in the correct state throughout the entire lifecycle of a resource—from pre-deployment gating to final deletion. This is achieved through four types of checks: `PreDeployChecks`, `ValidateHealthChecks`, `PreDeleteChecks`, and `PostDeleteChecks`.
 These checks are defined within the `spec` section of a `ClusterProfile` or a `Profile`.
+
+## Pre-Deploy Checks
+
+`PreDeployChecks` are executed *before* Sveltos deploys any resources for a given feature. If any check fails, deployment is held and retried later — no resources are applied until all checks pass. This is useful for enforcing prerequisites that must exist in the target cluster before an application is rolled out.
+
+```yaml
+spec:
+  preDeployChecks:
+  - name: "require-storage-class"
+    featureID: Resources
+    group: "storage.k8s.io"
+    version: "v1"
+    kind: "StorageClass"
+    labelFilters:
+    - key: tier
+      operation: Equal
+      value: ssd
+```
+
+In the example above, Sveltos will not deploy the `Resources` feature until at least one `StorageClass` with the label `tier=ssd` exists in the managed cluster.
 
 ## Validate Health Checks
 


### PR DESCRIPTION
Event Framework:
- Add a full `oneForEvent:false` example using range `.MatchingResources` to enforce a default-deny NetworkPolicy across all namespaces with a single ClusterProfile.
- Fix misleading sentence that implied oneForEvent:false does not support templating; replace with a cardinality explanation and a link to the new example.
- Promote the oneForEvent immutability note from plain text to a warning admonition.
- Clarify that the template variable name is singular (.MatchingResource/.Resource) with oneForEvent:true and plural (.MatchingResources/.Resources) with false; using the wrong form causes a rendering error.
- Fix Lua bug in aggregated_selection.md: deploymentsWithNoAutoscaler was declared but unusedAutoscalers was used (undeclared), causing a nil-index runtime error.

Lifecycle checks (pre_post_delete_checks.md, clusterprofile.md, profile.md):

- Add PreDeployChecks to the intro, add a ## Pre-Deploy Checks section with a labeled-StorageClass example, and insert Spec.PreDeployChecks entries in both ClusterProfile and Profile reference pages immediately before PreDeleteChecks.